### PR TITLE
Exposing some functionality to be reused in the LCA -> REMIND direction

### DIFF
--- a/rmnd_lca/__init__.py
+++ b/rmnd_lca/__init__.py
@@ -5,7 +5,8 @@ __all__ = (
     "NewDatabase",
     "Electricity",
     "BiofuelInventory",
-    "CarmaCCSInventory"
+    "CarmaCCSInventory",
+    "Geomap"
 )
 __version__ = (0, 0, 1)
 
@@ -18,4 +19,5 @@ from .data_collection import RemindDataCollection
 from .ecoinvent_modification import NewDatabase
 from .electricity import Electricity
 from .inventory_imports import CarmaCCSInventory, BiofuelInventory
+from .geomap import Geomap
 

--- a/rmnd_lca/activity_maps.py
+++ b/rmnd_lca/activity_maps.py
@@ -126,7 +126,6 @@ class InventorySet:
     }
 
     def __init__(self, db):
-        self.emissions_map = self.get_remind_to_ecoinvent_emissions()
         self.db = db
 
     def generate_material_map(self):

--- a/rmnd_lca/activity_maps.py
+++ b/rmnd_lca/activity_maps.py
@@ -6,17 +6,125 @@ REMIND_TO_ECOINVENT_EMISSION_FILEPATH = (DATA_DIR / "remind_to_ecoinvent_emissio
 
 class InventorySet:
     """
-    This class is used as a container for various dictionaries.
+    Hosts different filter sets to for ecoinvent activities and exchanges.
 
     It stores:
-    * activities_map: ecoinvent commodities as keys, ecoinvent dataset names as values
-    * powerplants_map: ecoinvent electricity technology as keys, dataset names as values
+    * material_filters: filters for activities related to materials.
+    * powerplant_filters: filters for activities related to power generation technologies.
     * emissions_map: REMIND emission labels as keys, ecoinvent emission labels as values
 
+    The functions :func:`generate_material_map` and :func:`generate_powerplant_map` can
+    be used to extract the actual activity objects as dictionaries.
+    These functions return the result of applying :func:`act_fltr` to the filter dictionaries.
     """
 
+    material_filters = {
+        "steel": {"fltr": "market for steel,", "mask": "hot rolled"},
+        "concrete": {"fltr": "market for concrete,"},
+        "copper": {"fltr": "market for copper", "filter_exact": True},
+        "aluminium": {
+            "fltr": ["market for aluminium, primary", "market for aluminium alloy,"]
+        },
+        "electricity": {"fltr": "market for electricity"},
+        "gas": {"fltr": "market for natural gas,", "mask": ["network", "burned"]},
+        "diesel": {"fltr": "market for diesel", "mask": ["burned", "electric"]},
+        "petrol": {"fltr": "market for petrol,", "mask": "burned"},
+        "freight": {"fltr": "market for transport, freight"},
+        "cement": {"fltr": "market for cement,"},
+        "heat": {"fltr": "market for heat,"},
+    }
 
-class InventorySet:
+    powerplant_filters = {
+        "Biomass IGCC CCS": {
+            "fltr": [
+                "Electricity, from CC plant, 100% SNG, truck 25km, post, pipeline 200km, storage 1000m/2025",
+                "Electricity, at wood burning power plant 20 MW, truck 25km, post, pipeline 200km, storage 1000m/2025",
+                "Electricity, at BIGCC power plant 450MW, pre, pipeline 200km, storage 1000m/2025",
+            ]
+        },
+        "Biomass IGCC": {
+            "fltr": "Electricity, at BIGCC power plant 450MW, no CCS/2025"
+        },
+        "Coal IGCC": {
+            "fltr": [
+                "Electricity, at power plant/hard coal, IGCC, no CCS/2025",
+                "Electricity, at power plant/lignite, IGCC, no CCS/2025",
+            ]
+        },
+        "Coal IGCC CCS": {
+            "fltr": [
+                "Electricity, at power plant/hard coal, pre, pipeline 200km, storage 1000m/2025",
+                "Electricity, at power plant/lignite, pre, pipeline 200km, storage 1000m/2025",
+            ]
+        },
+        "Coal PC CCS": {
+            "fltr": [
+                "Electricity, at power plant/hard coal, post, pipeline 200km, storage 1000m/2025",
+                "Electricity, at power plant/lignite, post, pipeline 200km, storage 1000m/2025",
+            ]
+        },
+        "Gas CCS": {
+            "fltr": [
+                "Electricity, at power plant/natural gas, pre, pipeline 200km, storage 1000m/2025",
+                "Electricity, at power plant/natural gas, post, pipeline 200km, storage 1000m/2025",
+            ]
+        },
+        "Biomass CHP": {
+            "fltr": [
+                "heat and power co-generation, wood chips",
+                "heat and power co-generation, biogas",
+            ]
+        },
+        "Coal PC": {
+            "fltr": [
+                "electricity production, hard coal",
+                "electricity production, lignite",
+            ],
+            "mask": "mine",
+        },
+        "Coal CHP": {
+            "fltr": [
+                "heat and power co-generation, hard coal",
+                "heat and power co-generation, lignite",
+            ]
+        },
+        "Gas OC": {
+            "fltr": "electricity production, natural gas, conventional power plant"
+        },
+        "Gas CC": {
+            "fltr": "electricity production, natural gas, combined cycle power plant"
+        },
+        "Gas CHP": {
+            "fltr": [
+                "heat and power co-generation, natural gas, combined cycle power plant, 400MW electrical",
+                "heat and power co-generation, natural gas, conventional power plant, 100MW electrical",
+            ]
+        },
+        "Geothermal": {"fltr": "electricity production, deep geothermal"},
+        "Hydro": {
+            "fltr": [
+                "electricity production, hydro, reservoir",
+                "electricity production, hydro, run-of-river",
+            ]
+        },
+        "Nuclear": {"fltr": "electricity production, nuclear", "mask": "aluminium"},
+        "Oil": {
+            "fltr": [
+                "electricity production, oil",
+                "heat and power co-generation, oil",
+            ],
+            "mask": "aluminium",
+        },
+        "Solar CSP": {
+            "fltr": [
+                "electricity production, solar thermal parabolic trough, 50 MW",
+                "electricity production, solar tower power plant, 20 MW",
+            ]
+        },
+        "Solar PV": {"fltr": "electricity production, photovoltaic"},
+        "Wind": {"fltr": "electricity production, wind"},
+    }
+
     def __init__(self, db):
         self.emissions_map = self.get_remind_to_ecoinvent_emissions()
         self.db = db
@@ -30,23 +138,8 @@ class InventorySet:
         :rtype: dict
 
         """
-        material_filters = {
-            "steel": {"fltr": "market for steel,", "mask": "hot rolled"},
-            "concrete": {"fltr": "market for concrete,"},
-            "copper": {"fltr": "market for copper", "filter_exact": True},
-            "aluminium": {
-                "fltr": ["market for aluminium, primary", "market for aluminium alloy,"]
-            },
-            "electricity": {"fltr": "market for electricity"},
-            "gas": {"fltr": "market for natural gas,", "mask": ["network", "burned"]},
-            "diesel": {"fltr": "market for diesel", "mask": ["burned", "electric"]},
-            "petrol": {"fltr": "market for petrol,", "mask": "burned"},
-            "freight": {"fltr": "market for transport, freight"},
-            "cement": {"fltr": "market for cement,"},
-            "heat": {"fltr": "market for heat,"},
-        }
 
-        return self.generate_sets_from_filters(material_filters)
+        return self.generate_sets_from_filters(self.material_filters)
 
     def generate_powerplant_map(self):
         """
@@ -57,97 +150,7 @@ class InventorySet:
         :rtype: dict
 
         """
-        powerplant_filters = {
-            "Biomass IGCC CCS": {
-                "fltr": [
-                    "Electricity, from CC plant, 100% SNG, truck 25km, post, pipeline 200km, storage 1000m/2025",
-                    "Electricity, at wood burning power plant 20 MW, truck 25km, post, pipeline 200km, storage 1000m/2025",
-                    "Electricity, at BIGCC power plant 450MW, pre, pipeline 200km, storage 1000m/2025",
-                ]
-            },
-            "Biomass IGCC": {
-                "fltr": "Electricity, at BIGCC power plant 450MW, no CCS/2025"
-            },
-            "Coal IGCC": {
-                "fltr": [
-                    "Electricity, at power plant/hard coal, IGCC, no CCS/2025",
-                    "Electricity, at power plant/lignite, IGCC, no CCS/2025",
-                ]
-            },
-            "Coal IGCC CCS": {
-                "fltr": [
-                    "Electricity, at power plant/hard coal, pre, pipeline 200km, storage 1000m/2025",
-                    "Electricity, at power plant/lignite, pre, pipeline 200km, storage 1000m/2025",
-                ]
-            },
-            "Coal PC CCS": {
-                "fltr": [
-                    "Electricity, at power plant/hard coal, post, pipeline 200km, storage 1000m/2025",
-                    "Electricity, at power plant/lignite, post, pipeline 200km, storage 1000m/2025",
-                ]
-            },
-            "Gas CCS": {
-                "fltr": [
-                    "Electricity, at power plant/natural gas, pre, pipeline 200km, storage 1000m/2025",
-                    "Electricity, at power plant/natural gas, post, pipeline 200km, storage 1000m/2025",
-                ]
-            },
-            "Biomass CHP": {
-                "fltr": [
-                    "heat and power co-generation, wood chips",
-                    "heat and power co-generation, biogas",
-                ]
-            },
-            "Coal PC": {
-                "fltr": [
-                    "electricity production, hard coal",
-                    "electricity production, lignite",
-                ],
-                "mask": "mine",
-            },
-            "Coal CHP": {
-                "fltr": [
-                    "heat and power co-generation, hard coal",
-                    "heat and power co-generation, lignite",
-                ]
-            },
-            "Gas OC": {
-                "fltr": "electricity production, natural gas, conventional power plant"
-            },
-            "Gas CC": {
-                "fltr": "electricity production, natural gas, combined cycle power plant"
-            },
-            "Gas CHP": {
-                "fltr": [
-                    "heat and power co-generation, natural gas, combined cycle power plant, 400MW electrical",
-                    "heat and power co-generation, natural gas, conventional power plant, 100MW electrical",
-                ]
-            },
-            "Geothermal": {"fltr": "electricity production, deep geothermal"},
-            "Hydro": {
-                "fltr": [
-                    "electricity production, hydro, reservoir",
-                    "electricity production, hydro, run-of-river",
-                ]
-            },
-            "Nuclear": {"fltr": "electricity production, nuclear", "mask": "aluminium"},
-            "Oil": {
-                "fltr": [
-                    "electricity production, oil",
-                    "heat and power co-generation, oil",
-                ],
-                "mask": "aluminium",
-            },
-            "Solar CSP": {
-                "fltr": [
-                    "electricity production, solar thermal parabolic trough, 50 MW",
-                    "electricity production, solar tower power plant, 20 MW",
-                ]
-            },
-            "Solar PV": {"fltr": "electricity production, photovoltaic"},
-            "Wind": {"fltr": "electricity production, wind"},
-        }
-        return self.generate_sets_from_filters(powerplant_filters)
+        return self.generate_sets_from_filters(self.powerplant_filters)
 
     def get_remind_to_ecoinvent_emissions(self):
         """

--- a/rmnd_lca/activity_maps.py
+++ b/rmnd_lca/activity_maps.py
@@ -70,10 +70,13 @@ class InventorySet:
             ]
         },
         "Biomass CHP": {
-            "fltr": [
-                "heat and power co-generation, wood chips",
-                "heat and power co-generation, biogas",
-            ]
+            "fltr": {
+                "name":[
+                    "heat and power co-generation, wood chips",
+                    "heat and power co-generation, biogas",
+                ],
+                "reference product": "electricity"
+            }
         },
         "Coal PC": {
             "fltr": [
@@ -83,10 +86,13 @@ class InventorySet:
             "mask": "mine",
         },
         "Coal CHP": {
-            "fltr": [
-                "heat and power co-generation, hard coal",
-                "heat and power co-generation, lignite",
-            ]
+            "fltr": {
+                "name": [
+                    "heat and power co-generation, hard coal",
+                    "heat and power co-generation, lignite",
+                ],
+                "reference product": "electricity"
+            }
         },
         "Gas OC": {
             "fltr": "electricity production, natural gas, conventional power plant"
@@ -95,10 +101,13 @@ class InventorySet:
             "fltr": "electricity production, natural gas, combined cycle power plant"
         },
         "Gas CHP": {
-            "fltr": [
-                "heat and power co-generation, natural gas, combined cycle power plant, 400MW electrical",
-                "heat and power co-generation, natural gas, conventional power plant, 100MW electrical",
-            ]
+            "fltr": {
+                "name": [
+                    "heat and power co-generation, natural gas, combined cycle power plant, 400MW electrical",
+                    "heat and power co-generation, natural gas, conventional power plant, 100MW electrical",
+                ],
+                "reference product": "electricity"
+            }
         },
         "Geothermal": {"fltr": "electricity production, deep geothermal"},
         "Hydro": {
@@ -109,10 +118,13 @@ class InventorySet:
         },
         "Nuclear": {"fltr": "electricity production, nuclear", "mask": "aluminium"},
         "Oil": {
-            "fltr": [
+            "fltr": {
+                "name": [
                 "electricity production, oil",
                 "heat and power co-generation, oil",
-            ],
+                ],
+                "reference product": "electricity"
+            },
             "mask": "aluminium",
         },
         "Solar CSP": {

--- a/rmnd_lca/ecoinvent_modification.py
+++ b/rmnd_lca/ecoinvent_modification.py
@@ -4,6 +4,7 @@ from .data_collection import RemindDataCollection
 from .electricity import Electricity
 from .inventory_imports import CarmaCCSInventory, BiofuelInventory
 from .export import Export
+from .utils import eidb_label
 import pyprind
 import wurst
 import os
@@ -69,7 +70,7 @@ class NewDatabase:
 
     def write_db_to_brightway(self):
         print('Write new database to Brightway2.')
-        wurst.write_brightway2_database(self.db, "ecoinvent_"+ self.scenario + "_" + str(self.year))
+        wurst.write_brightway2_database(self.db, eidb_label(self.scenario, self.year))
 
     def write_db_to_matrices(self):
         print("Write new database to matrix.")

--- a/rmnd_lca/electricity.py
+++ b/rmnd_lca/electricity.py
@@ -34,7 +34,7 @@ class Electricity:
         self.fuels_lhv = self.get_lower_heating_values()
 
         mapping = InventorySet(self.db)
-        self.emissions_map = mapping.emissions_map
+        self.emissions_map = mapping.get_remind_to_ecoinvent_emissions()
         self.powerplant_map = mapping.generate_powerplant_map()
 
     def get_lower_heating_values(self):

--- a/rmnd_lca/electricity.py
+++ b/rmnd_lca/electricity.py
@@ -32,10 +32,10 @@ class Electricity:
         self.scenario = scenario
         self.year = year
         self.fuels_lhv = self.get_lower_heating_values()
+
         mapping = InventorySet(self.db)
-        self.activities_map = mapping.activities_map
-        self.powerplant_map = mapping.powerplants_map
         self.emissions_map = mapping.emissions_map
+        self.powerplant_map = mapping.generate_powerplant_map()
 
     def get_lower_heating_values(self):
         """
@@ -55,7 +55,7 @@ class Electricity:
         respectively.
 
         :param ecoinvent_regions: an ecoinvent region
-        :type ecoinvent_regions: str
+        :type ecoinvent_regions: list
         :param ecoinvent_technologies: name of ecoinvent dataset
         :type ecoinvent_technologies: str
         :return: list of wurst datasets

--- a/rmnd_lca/geomap.py
+++ b/rmnd_lca/geomap.py
@@ -1,0 +1,117 @@
+from wurst.geo import geomatcher
+
+from rmnd_lca import DATA_DIR
+REGION_MAPPING_FILEPATH = (DATA_DIR /  "regionmappingH12.csv")
+
+class Geomap():
+    """
+    Map ecoinvent locations to REMIND regions and vice-versa.
+    """
+    def __init__(self):
+        self.geo = self.get_REMIND_geomatcher()
+
+    def get_REMIND_geomatcher(self):
+        """
+        Load a geomatcher object from the `constructive_geometries`library and add definitions.
+        It is used to find correspondences between REMIND and ecoinvent region names.
+        :return: geomatcher object
+        :rtype: wurst.geo.geomatcher
+        """
+        with open(REGION_MAPPING_FILEPATH) as f:
+            f.readline()
+            csv_list = [[val.strip() for val in r.split(";")] for r in f.readlines()]
+            l = [(x[1], x[2]) for x in csv_list]
+
+        # List of countries not found
+        countries_not_found = ["CC", "CX", "GG", "JE", "BL"]
+
+        rmnd_to_iso = {}
+        iso_to_rmnd = {}
+        # Build a dictionary that maps region names (used by REMIND) to ISO country codes
+        # And a reverse dictionary that maps ISO country codes to region names
+        for ISO, region in l:
+            if ISO not in countries_not_found:
+                try:
+                    rmnd_to_iso[region].append(ISO)
+                except KeyError:
+                    rmnd_to_iso[region] = [ISO]
+
+                iso_to_rmnd[region] = ISO
+
+        geo = geomatcher
+        geo.add_definitions(rmnd_to_iso, "REMIND")
+
+        return geo
+
+    def remind_to_ecoinvent_location(self, location):
+        """
+        Find the corresponding ecoinvent region given a REMIND region.
+
+        :param location: name of a REMIND region
+        :type location: str
+        :return: name of an ecoinvent region
+        :rtype: str
+        """
+
+        if location != "World":
+            location = ("REMIND", location)
+
+            ecoinvent_locations = []
+            try:
+                for r in self.geo.intersects(location):
+                    if not isinstance(r, tuple):
+                        ecoinvent_locations.append(r)
+                return ecoinvent_locations
+            except KeyError as e:
+                print("Can't find location {} using the geomatcher.".format(location))
+
+        else:
+            return ["GLO"]
+
+    def ecoinvent_to_remind_location(self, location):
+        """
+        Return a REMIND region name for a 2-digit ISO country code given.
+        Set rules in case two REMIND regions are within the ecoinvent region.
+
+        :param location: 2-digit ISO country code
+        :type location: str
+        :return: REMIND region name
+        :rtype: str
+        """
+
+        mapping = {"GLO": "World", "RoW": "CAZ", "IAI Area, Russia & RER w/o EU27 & EFTA": "REF"}
+        if location in mapping:
+            return mapping[location]
+
+        remind_location = [
+            r[1]
+            for r in self.geo.within(location)
+            if r[0] == "REMIND" and r[1] != "World"
+        ]
+
+        mapping = {
+            ("AFR", "MEA"): "AFR",
+            ("AFR", "SSA"): "AFR",
+            ("EUR", "NEU"): "EUR",
+            ("EUR", "REF"): "EUR",
+            ("OAS", "CHA"): "OAS",
+            ("OAS", "EUR"): "OAS",
+            ("OAS", "IND"): "OAS",
+            ("OAS", "JPN"): "OAS",
+            ("OAS", "MEA"): "OAS",
+            ("OAS", "REF"): "OAS",
+            ("USA", "CAZ"): "USA",
+        }
+
+        # If we have more than one REMIND region
+        if len(remind_location) > 1:
+            # TODO: find a more elegant way to do that
+            for key, value in mapping.items():
+                # We need to find the most specific REMIND region
+                if len(set(remind_location).intersection(set(key))) == 2:
+                    remind_location.remove(value)
+            return remind_location[0]
+        elif len(remind_location) == 0:
+            print("no location for {}".format(location))
+        else:
+            return remind_location[0]

--- a/rmnd_lca/utils.py
+++ b/rmnd_lca/utils.py
@@ -1,0 +1,2 @@
+def eidb_label(scenario, year):
+    return "ecoinvent_"+ scenario + "_" + str(year)

--- a/tests/test_activity_maps.py
+++ b/tests/test_activity_maps.py
@@ -24,18 +24,20 @@ dummy_minimal_db = [{'name': 'Electricity, at BIGCC power plant 450MW, pre, pipe
 
 def test_presence_of_dict():
     maps = InventorySet(dummy_minimal_db)
-    assert isinstance(maps.activities_map, dict)
-    assert isinstance(maps.powerplants_map, dict)
     assert isinstance(maps.emissions_map, dict)
+    assert isinstance(maps.generate_material_map(), dict)
+    assert isinstance(maps.generate_powerplant_map(), dict)
 
 def test_length_dict():
     maps = InventorySet(dummy_minimal_db)
-    assert len(maps.activities_map) > 0
-    assert len(maps.powerplants_map) > 0
     assert len(maps.emissions_map) > 0
+    assert len(maps.generate_material_map()) > 0
+    assert len(maps.generate_powerplant_map()) > 0
 
 def test_content_dict():
     maps = InventorySet(dummy_minimal_db)
-    assert maps.activities_map['aluminium'] == {'market for aluminium, primary'}
-    assert maps.powerplants_map['Coal IGCC'] == {'Electricity, at power plant/lignite, IGCC, no CCS/2025'}
+    materials = maps.generate_material_map()
+    assert materials['aluminium'] == {'market for aluminium, primary'}
+    plants = maps.generate_powerplant_map()
+    assert plants['Coal IGCC'] == {'Electricity, at power plant/lignite, IGCC, no CCS/2025'}
     assert maps.emissions_map['Sulfur dioxide'] == 'SO2'

--- a/tests/test_activity_maps.py
+++ b/tests/test_activity_maps.py
@@ -24,13 +24,13 @@ dummy_minimal_db = [{'name': 'Electricity, at BIGCC power plant 450MW, pre, pipe
 
 def test_presence_of_dict():
     maps = InventorySet(dummy_minimal_db)
-    assert isinstance(maps.emissions_map, dict)
+    assert isinstance(maps.get_remind_to_ecoinvent_emissions(), dict)
     assert isinstance(maps.generate_material_map(), dict)
     assert isinstance(maps.generate_powerplant_map(), dict)
 
 def test_length_dict():
     maps = InventorySet(dummy_minimal_db)
-    assert len(maps.emissions_map) > 0
+    assert len(maps.get_remind_to_ecoinvent_emissions()) > 0
     assert len(maps.generate_material_map()) > 0
     assert len(maps.generate_powerplant_map()) > 0
 
@@ -40,4 +40,5 @@ def test_content_dict():
     assert materials['aluminium'] == {'market for aluminium, primary'}
     plants = maps.generate_powerplant_map()
     assert plants['Coal IGCC'] == {'Electricity, at power plant/lignite, IGCC, no CCS/2025'}
-    assert maps.emissions_map['Sulfur dioxide'] == 'SO2'
+    emissions = maps.get_remind_to_ecoinvent_emissions()
+    assert emissions['Sulfur dioxide'] == 'SO2'

--- a/tests/test_activity_maps.py
+++ b/tests/test_activity_maps.py
@@ -22,6 +22,11 @@ dummy_minimal_db = [{'name': 'Electricity, at BIGCC power plant 450MW, pre, pipe
  {'name': 'electricity production, wind, 2.3MW turbine, precast concrete tower, onshore'}, {'name': 'steel production'},
  {'name':'market for aluminium, primary'}]
 
+for act in dummy_minimal_db:
+    act["location"] = "DE"
+    act["unit"] = "kilowatt hour"
+    act["reference product"] = "electricity"
+
 def test_presence_of_dict():
     maps = InventorySet(dummy_minimal_db)
     assert isinstance(maps.get_remind_to_ecoinvent_emissions(), dict)

--- a/tests/test_electricity.py
+++ b/tests/test_electricity.py
@@ -46,10 +46,6 @@ def test_losses():
 def test_fuels_lhv():
     assert float(el.fuels_lhv['hard coal']) == 20.1
 
-def test_activities_map():
-    s = el.activities_map['steel']
-    assert isinstance(s, set)
-
 def test_powerplant_map():
     s = el.powerplant_map['Biomass IGCC CCS']
     assert isinstance(s, set)

--- a/tests/test_geomap.py
+++ b/tests/test_geomap.py
@@ -1,0 +1,19 @@
+import pytest
+from rmnd_lca.geomap import Geomap
+
+geomap = Geomap()
+
+def test_ecoinvent_to_REMIND():
+    # DE is in EUR
+    assert geomap.ecoinvent_to_remind_location("DE") == "EUR"
+    # CN is in CHA
+    assert geomap.ecoinvent_to_remind_location("CN") == "CHA"
+
+def test_REMIND_to_ecoinvent():
+    # DE and CH are in EUR (at least for now)
+    assert "DE" in geomap.remind_to_ecoinvent_location("EUR")
+    assert "CH" in geomap.remind_to_ecoinvent_location("EUR")
+    # Hongkong is in China (really?)
+    assert "HK" in geomap.remind_to_ecoinvent_location("CHA")
+    # in Japan there is only GLO and JP
+    assert ["GLO", "JP"] == geomap.remind_to_ecoinvent_location("JPN")


### PR DESCRIPTION
Includes the following changes:
- a new module `utils` comprising a function to generate brightway db identifiers from scenario and year.
- move the geomapper functionality out of the `Electricity` class into its own.
- add test for the new `Geomap` class.
- move the generation of ecoinvent-to-REMIND activity maps out of the constructor of `InventoryMaps` class. New functions return the dictionaries explicitly, making the class more lightweight.